### PR TITLE
Fixed System.Configuration.ConfigurationManager package version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.0.2]
+
+- Fixed `System.Configuration.ConfigurationManager` version in nuspec.
+
 ## [2.0.1]
 
 ### Added

--- a/src/Geta.Net.Extensions/Geta.Net.Extensions.nuspec
+++ b/src/Geta.Net.Extensions/Geta.Net.Extensions.nuspec
@@ -12,7 +12,7 @@
     <tags>Geta Foundation .NET Extensions library</tags>
     <dependencies>
       <dependency id="NETStandard.Library" version="2.*" />
-      <dependency id="System.Configuration.ConfigurationManager" version="4.*" />
+      <dependency id="System.Configuration.ConfigurationManager" version="[4.6.0,5)" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
System.Configuration.ConfigurationManager version in nuspec didn't match the installed package in the project. For this reason, the project builds had warnings as the version in nuspec does not exist at all.